### PR TITLE
Fix periodic saver startup and shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,7 +138,8 @@ async def periodic_saver():
 @bot.event
 async def on_ready():
     print(f"Bot connecté : {bot.user.name}")
-    periodic_saver.start()
+    if not periodic_saver.is_running():
+        periodic_saver.start()
 
 @bot.event
 async def on_command_error(ctx, error):
@@ -471,11 +472,17 @@ for extension in startup_extensions:
 async def stop_bot(ctx):
     """Arrête le bot proprement (sauvegarde cache, arrête la loop)."""
     await ctx.send("Bot is shutting down...")
-    periodic_saver.cancel()
+    if periodic_saver.is_running():
+        periodic_saver.cancel()
     save_cache_to_json_files()
     await bot.close()
 
 # ─────────────────────────────────────────────
 #          LANCEMENT DU BOT
 # ─────────────────────────────────────────────
-bot.run(config["token"])
+try:
+    bot.run(config["token"])
+finally:
+    if periodic_saver.is_running():
+        periodic_saver.cancel()
+    save_cache_to_json_files()


### PR DESCRIPTION
## Summary
- start periodic saver only if it's not already running
- stop periodic saver before closing in the `stop_bot` command
- always stop periodic saver and save cache on any shutdown

## Testing
- `python -m py_compile main.py cogs/dice_rolls.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877361cb8c833284d6dd5f04fea24b